### PR TITLE
chore: configure review controls

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# Editor configuration for term-dash
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @bcarlson

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,28 @@
+---
+name: "\U0001F41E Bug report"
+about: Report a defect or regression in term-dash
+title: "[Bug] "
+labels: ["bug"]
+assignees: []
+---
+
+## Summary
+<!-- One-sentence description of the bug -->
+
+## Steps to Reproduce
+1. 
+2. 
+
+## Expected Result
+<!-- What should happen -->
+
+## Actual Result
+<!-- What actually happens; include screenshots or recordings when helpful -->
+
+## Environment
+- OS / Terminal:
+- Rust toolchain (`rustc --version`):
+- Branch / commit:
+
+## Additional Context
+<!-- Logs, configs, or related issues -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security Report
+    url: https://github.com/bcarlson/term-dash/security/advisories/new
+    about: Please report security vulnerabilities privately.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: "\U0001F680 Feature request"
+about: Propose a new capability for term-dash
+title: "[Feature] "
+labels: ["enhancement"]
+assignees: []
+---
+
+## Problem Statement
+<!-- Briefly describe the user need or pain point -->
+
+## Proposed Solution
+<!-- High-level summary of the requested feature -->
+
+## User Impact
+<!-- Who benefits and how success is measured -->
+
+## Alternatives Considered
+<!-- Optional: other approaches you evaluated -->
+
+## Additional Context
+<!-- Mock-ups, references, or related issues -->

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,19 @@
+---
+name: "\U0001F527 Maintenance task"
+about: Track chores, refactors, or dependency updates
+title: "[Task] "
+labels: ["maintenance"]
+assignees: []
+---
+
+## Objective
+<!-- Short goal statement -->
+
+## Scope
+<!-- Key actions or sub-tasks -->
+
+## Testing Plan
+<!-- How we will validate the task is done -->
+
+## Notes
+<!-- Dependencies, scheduling, or follow-ups -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Summary
+- 
+- 
+
+## Testing
+- [ ] `cargo fmt`
+- [ ] `cargo clippy --all-targets --all-features`
+- [ ] `cargo test`
+- [ ] Additional verification (describe):
+
+## Screenshots / Recordings
+<!-- Attach terminal captures when UI output changes -->
+
+## Checklist
+- [ ] Linked related issues or tickets
+- [ ] Updated docs, examples, or configs as needed
+- [ ] Requested review from @bcarlson (required for main merges)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,25 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+Follow standard crate layout: keep `Cargo.toml` at the root and put the runtime entry in `src/main.rs` (or `src/bin/term-dash.rs` once multiple binaries exist). Organize reusable logic under `src/` modules such as `src/widgets/` for TUI components, `src/data/` for adapters, and `src/app.rs` for orchestration. Store sample configs or ASCII templates under `assets/` or `examples/`. Co-locate focused unit tests with their modules using `#[cfg(test)]`, and keep integration flows in `tests/`.
+
+## Build, Test, and Development Commands
+- `cargo build`: compile the crate and surface borrow-checker issues early.
+- `cargo run --bin term-dash`: run the dashboard binary (adjust if more bins appear).
+- `cargo test`: execute unit and integration tests.
+- `cargo fmt && cargo clippy --all-targets --all-features`: enforce formatting and linting in one step.
+
+## Coding Style & Naming Conventions
+Run `rustfmt` before committing (4-space indentation, 100-column wrapping). Follow idiomatic Rust naming: snake_case for files/modules/functions, CamelCase for types/traits, SCREAMING_SNAKE_CASE for constants. Keep modules cohesive, prefer pure functions returning `Result<T, anyhow::Error>`, and isolate side effects near the entry point. Document public APIs with Rustdoc and add inline notes only when rendering logic is non-obvious.
+
+## Testing Guidelines
+Each new module should include `#[cfg(test)]` unit coverage, while behavior-level scenarios go into `tests/` with filenames such as `tests/layout_resize.rs`. Ensure both `cargo test` and `cargo test --release` pass before opening a PR.
+
+## Commit & Pull Request Guidelines
+Use concise, imperative commit messages: `feat(layout): add grid widget` or `fix(data): guard empty payload`. Group related work so each commit builds cleanly. Pull requests should summarize the change, list verification steps, link issues, and include terminal screenshots or recordings when UI output shifts.
+
+## Code Review & Approvals
+Create topic branches from `main` (e.g., `git checkout -b feature/layout-grid`) and push them for review against `protentions`. All merges into `main` require approval from Brian Carlson; request their review explicitly and block merging until they approve. Highlight risky areas, attach logs or recordings for UI updates, and note follow-up issues so the approver can sign off confidently.
+
+## Local Environment Setup
+Install the latest stable toolchain via `rustup` and add the `clippy` and `rustfmt` components. `cargo install cargo-watch cargo-udeps` keeps feedback fast and dependencies tidy; a typical loop is `cargo watch -x "check" -x "test"`. Capture screenshots at 24×80 or wider so comparisons stay consistent.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,58 @@
+# Code of Conduct
+
+## Our Pledge
+We as members, contributors, and leaders pledge to make participation in the term-dash project and community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+Examples of behavior that contributes to a positive environment include:
+- Demonstrating empathy and kindness toward other people.
+- Being respectful of differing opinions, viewpoints, and experiences.
+- Giving and gracefully accepting constructive feedback.
+- Accepting responsibility and apologizing to those affected by mistakes, and learning from the experience.
+- Focusing on what is best not just for us as individuals, but for the overall community.
+
+Examples of unacceptable behavior include:
+- The use of sexualized language or imagery, and sexual attention or advances of any kind.
+- Trolling, insulting or derogatory comments, and personal or political attacks.
+- Public or private harassment.
+- Publishing others’ private information, such as a physical or email address, without their explicit permission.
+- Other conduct which could reasonably be considered inappropriate in a professional setting.
+
+## Enforcement Responsibilities
+Project maintainers are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+This Code of Conduct applies within all project spaces, and also applies when an individual is officially representing the project in public spaces. Examples of representing the project include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project maintainer team at `security@nitro33.com`. All complaints will be reviewed and investigated promptly and fairly.
+
+The project maintainer team is obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+Project maintainers will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.  
+**Consequence**: A private, written warning from project maintainers, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+**Community Impact**: A violation through a single incident or series of actions.  
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in project spaces as well as external channels like social media.
+
+### 3. Temporary Ban
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.  
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period.
+
+### 4. Permanent Ban
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.  
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.
+
+For answers to common questions about this code of conduct, see the [FAQ](https://www.contributor-covenant.org/faq). Translations are available at the [Contributor Covenant homepage](https://www.contributor-covenant.org/translations).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+# Contributing to term-dash
+
+Thanks for your interest in improving term-dash! This document outlines the contributor process and points you to deeper references.
+
+## Code of Conduct
+Participation is governed by the [Code of Conduct](CODE_OF_CONDUCT.md). Please make sure your interactions stay respectful and inclusive.
+
+## Getting Started
+1. Review the repository playbook in [AGENTS.md](AGENTS.md) for expectations on project layout, coding style, testing, and approvals.
+2. Fork the repository or create a topic branch from `main` (or `protentions` while the bootstrap branch is active).
+3. Install the latest Rust toolchain with `rustup`, plus `clippy` and `rustfmt` components.
+
+## Development Workflow
+- Prefer small, focused commits with imperative messages (e.g., `feat(widget): add sparkline renderer`).
+- Keep code formatted via `cargo fmt` and linted with `cargo clippy --all-targets --all-features`.
+- Run `cargo test` (and `cargo test --release` for performance-sensitive changes) before submitting.
+- Update docs, examples, and fixtures when behavior changes.
+
+## Pull Requests
+- Draft PRs when work is in progress; convert to ready-for-review once checks pass.
+- Fill out the pull request template, including verification steps and screenshots for UI changes.
+- Brian Carlson is currently the required approver for merges to `main`; request their review explicitly.
+
+## Reporting Issues
+Use the provided issue templates for bugs, feature ideas, and maintenance tasks. Include reproduction steps, environment details, and proposed solutions when possible.
+
+## Questions
+Open a GitHub Discussion (once enabled) or file an issue using the “Task” template to ask for clarification. You can also mention `@bcarlson` directly on GitHub for guidance.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# term-dash
+
+term-dash is an upcoming Rust-powered terminal dashboard for monitoring systems and developer workflows from the command line. The project is still in its bootstrap phase; use this README as the canonical source for roadmap, setup, and contribution guidance.
+
+## Project Status
+Active development has not yet begun. Initial tasks include seeding the Rust crate structure, defining core widgets, and wiring data adapters. Track progress via GitHub Projects or the issue tracker.
+
+## Getting Started
+1. Install the latest stable Rust toolchain with `rustup`.
+2. Clone the repository and create a feature branch from `protentions` until `main` becomes the default development branch.
+3. Run `cargo build` once the crate lands to verify your environment.
+
+## Development Workflow
+- Follow the repository playbook in `AGENTS.md` for module layout, coding standards, and review expectations.
+- Use `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo test` before opening a pull request.
+- Capture terminal screenshots at 24×80 or wider when UI output changes.
+
+## Contributing
+We welcome issues and pull requests for features, bug fixes, documentation, and tooling. Please:
+- Review `CONTRIBUTING.md` for contribution logistics.
+- Read the Code of Conduct to ensure a welcoming environment.
+- Use the issue templates provided for bugs, feature requests, and tasks.
+
+## Security
+Report vulnerabilities privately via the Security advisory form linked in `SECURITY.md`. Please do not open public issues for security concerns.
+
+## License
+term-dash is released under the MIT License. See `LICENSE` for details.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security Policy
+
+## Supported Versions
+term-dash is currently in pre-release development. All branches are supported on a best-effort basis until tagged releases are published. Security fixes will target `main`, and patch releases will be cut as needed once versioned builds exist.
+
+## Reporting a Vulnerability
+- Submit a private advisory via the GitHub Security tab or email `security@nitro33.com`.
+- Provide detailed reproduction steps, impact assessment, and any suggested mitigations.
+- Expect an initial response within 5 business days. We will coordinate disclosure timelines to ensure a fix or acceptable mitigation is available before public disclosure.
+
+Please avoid filing public issues for security vulnerabilities until we coordinate a disclosure plan.


### PR DESCRIPTION
## Summary
- add CODEOWNERS so Brian Carlson is requested on every change
- configure main branch protections (admin enforcement, linear history, conversation resolution)
- add issue templates for bugs, features, and maintenance to standardize reports
- bootstrap README, CONTRIBUTING, CODE_OF_CONDUCT, SECURITY, editorconfig, and PR template for OSS best practices

## Testing
- not applicable