### PR TITLE
chore: add docker tooling

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+target
+**/target
+.git
+.gitignore
+.github
+.env
+.idea
+.vscode
+Dockerfile
+docker-compose.yml
+README.md
+LICENSE
+AGENTS.md
+CODE_OF_CONDUCT.md
+CONTRIBUTING.md
+SECURITY.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+# syntax=docker/dockerfile:1.4
+
+ARG RUST_VERSION=1.75
+FROM rust:${RUST_VERSION}-slim AS runtime
+
+ARG USER_ID=1000
+ARG GROUP_ID=1000
+ARG USER_NAME=rustdev
+
+ENV CARGO_HOME=/usr/local/cargo \
+    RUSTUP_HOME=/usr/local/rustup \
+    PATH=/usr/local/cargo/bin:/usr/local/rustup/toolchains/${RUST_VERSION}-x86_64-unknown-linux-gnu/bin:$PATH
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        pkg-config \
+        libssl-dev \
+        ca-certificates \
+        curl \
+        build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN groupadd -g ${GROUP_ID} ${USER_NAME} \
+    && useradd -m -u ${USER_ID} -g ${GROUP_ID} ${USER_NAME}
+
+WORKDIR /workspace
+
+# Pre-fetch dependencies if Cargo manifest exists (optional during build).
+COPY Cargo.toml Cargo.lock* ./
+COPY src ./src
+RUN if [ -f Cargo.toml ]; then cargo fetch; fi
+
+USER ${USER_NAME}
+
+CMD ["bash"]

--- a/README.md
+++ b/README.md
@@ -8,12 +8,27 @@ Active development has not yet begun. Initial tasks include seeding the Rust cra
 ## Getting Started
 1. Install the latest stable Rust toolchain with `rustup`.
 2. Clone the repository and create a feature branch from `protentions` until `main` becomes the default development branch.
-3. Run `cargo build` once the crate lands to verify your environment.
+3. Run `cargo run` to launch the retro clock demo (press `q` to quit).
 
 ## Development Workflow
 - Follow the repository playbook in `AGENTS.md` for module layout, coding standards, and review expectations.
 - Use `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo test` before opening a pull request.
 - Capture terminal screenshots at 24×80 or wider when UI output changes.
+
+## Retro Clock Demo
+- Rendered with ASCII pipes, segments, and dots to mimic an 80s digital clock.
+- Resizes automatically to fill the available terminal space; window changes apply roughly every 200ms.
+- Falls back to a compact readout if the window becomes too small.
+
+## Docker Workflow
+1. Install Docker Desktop (or Engine) and Docker Compose.
+2. Build the image with `docker compose build`.
+3. Run commands inside the container, for example:
+   - `docker compose run --rm dev cargo fmt`
+   - `docker compose run --rm dev cargo test`
+   - `docker compose run --rm dev cargo run`
+4. The container mounts the repository at `/workspace`; results sync back to your host.
+5. Override the user and group IDs by exporting `UID`/`GID` before invoking Compose to align container permissions with your local user.
 
 ## Contributing
 We welcome issues and pull requests for features, bug fixes, documentation, and tooling. Please:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+services:
+  dev:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        RUST_VERSION: ${RUST_VERSION:-1.75}
+        USER_ID: ${UID:-1000}
+        GROUP_ID: ${GID:-1000}
+        USER_NAME: ${USER_NAME:-rustdev}
+    volumes:
+      - .:/workspace
+      - cargo-cache:/usr/local/cargo/registry
+      - target-cache:/workspace/target
+    working_dir: /workspace
+    environment:
+      - CARGO_TERM_COLOR=always
+    command: bash
+
+volumes:
+  cargo-cache:
+  git-cache:
+  target-cache:


### PR DESCRIPTION
## Summary
- add Dockerfile and docker compose service for running cargo tasks in a containerized toolchain
- document the Docker-based workflow alongside the retro clock demo instructions
- include .dockerignore to keep build context slim

## Testing
- docker compose build
- docker compose run --rm dev cargo --version
